### PR TITLE
Fix incorrect doc comments for `P256_point_is_on_curve`

### DIFF
--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -69,12 +69,10 @@ pub(crate) static P256_PRIME: [u32; 8] =
 /// # Return
 /// On return, `r0` will contain `1` if `xy` is on the `p256` curve. Otherwise, `r0` will contain `0`.
 ///
-/// All other registers are clobbered.
+/// # SAFETY
+/// The caller must guarantee that `x` and `y` are valid.
 ///
-/// # Safety
-/// The caller must ensure that the ABI for this function is upheld. It is impossible to do so from
-/// normal rust code, so it must only be called from other inline assembly.
-// TODO: make this `extern "custom"` once that is stabilized (https://github.com/rust-lang/rust/issues/140829)
+/// This function adheres to the ARM calling convention.
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".p256-cortex-m4")]
 #[unsafe(naked)]

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -352,7 +352,12 @@ pub unsafe extern "C" fn P256_decompress_point(
 /// > **Note**: `r0` will be overriden during the execution of this function (it is callee-saved).
 #[unsafe(no_mangle)]
 #[unsafe(naked)]
-pub unsafe extern "C" fn P256_negate_mod_m_if() {
+pub unsafe extern "C" fn P256_negate_mod_m_if(
+    output: *mut [u32; 8],
+    a: *const [u32; 8],
+    should_negate: u32,
+    m: *const [u32; 8],
+) {
     naked_asm!(
         "
                 push {r4-r8, lr}


### PR DESCRIPTION
See title. Only minor, but gave me a bit of a heart attack when I read the (wrong) comment I had added myself :P