### PR TITLE
Add `sys` module and hide all `asm` functions within it.

### DIFF
--- a/p256-cm4/src/asm/add_sub.rs
+++ b/p256-cm4/src/asm/add_sub.rs
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn P256_addmod() {
 /// > **Note**: `r0` will be overriden during the execution of this function (it is callee-saved).
 #[unsafe(no_mangle)]
 #[unsafe(naked)]
-pub unsafe extern "C" fn P256_add_mod_n(
+pub(in crate::sys) unsafe extern "C" fn P256_add_mod_n(
     res: *mut [u32; 8],
     a: *const [u32; 8],
     b: *const [u32; 8],

--- a/p256-cm4/src/asm/jacobian.rs
+++ b/p256-cm4/src/asm/jacobian.rs
@@ -14,10 +14,14 @@ use crate::sys::asm::Montgomery;
 /// # Return
 /// On return, the dereference of the input value of `r0` will contain the result of the computation.
 ///
-/// > **Note**: `r0` will be overriden during the execution of this function (it is callee-saved).
+/// # Safety
+/// The caller must guarantee that `jacobian_out` and `jacobian_in` are valid for
+/// the duration of the function, and that `jacobian_out` is valid for writes.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn P256_double_j(
+pub(in crate::sys) unsafe extern "C" fn P256_double_j(
     jacobian_out: *mut [Montgomery; 3],
     jacobian_in: *const [Montgomery; 3],
 ) {

--- a/p256-cm4/src/asm/jacobian.rs
+++ b/p256-cm4/src/asm/jacobian.rs
@@ -222,7 +222,7 @@ pub unsafe extern "C" fn P256_times2() {
 ///
 /// `r1` shall contain `b`, which must not be the point at infinity:
 /// 1. if `r3 == 0`, a valid [`*const [Montgomery; 3]`](super::Montgomery).
-/// 2. else, a valid `*const [[u32; 8]; 2]`.
+/// 2. else, a valid [`*const [Montgomery; 2]`](Montgomery).
 ///
 /// `r2` shall contain `is_sub`, a boolean.
 ///
@@ -233,12 +233,17 @@ pub unsafe extern "C" fn P256_times2() {
 /// # Return
 /// On return, the location pointed to by the input `r0` will contain the result of the operation.
 ///
-/// > **Note**: `r0` will be overriden during the execution of this function (it is callee-saved).
+/// # Safety
+/// The caller must guarantee that `a` and `b` are valid for the duration of the function call,
+/// that `a` is valid for writes, and that `b` has the correct length w.r.t. the value of
+/// `b_is_affine`.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn P256_add_sub_j(
+pub(in crate::sys) unsafe extern "C" fn P256_add_sub_j(
     a: *mut [Montgomery; 3],
-    b: *const u32,
+    b: *const Montgomery,
     is_sub: bool,
     b_is_affine: bool,
 ) {

--- a/p256-cm4/src/asm/jacobian.rs
+++ b/p256-cm4/src/asm/jacobian.rs
@@ -540,7 +540,11 @@ pub(in crate::sys) unsafe extern "C" fn P256_add_sub_j(
 /// # Return
 /// On return, the locations pointed to by the input `r0` and `r0` will contain the results of the operation.
 ///
-/// > **Note**: `r0` will be overriden during the execution of this function (it is callee-saved).
+/// # Safety
+/// The caller must guarantee that `x`, `y` and `a` are valid for the duration of the function
+/// call, and that `x` and `y` are valid for writes.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn P256_jacobian_to_affine(

--- a/p256-cm4/src/asm/jacobian.rs
+++ b/p256-cm4/src/asm/jacobian.rs
@@ -1,6 +1,6 @@
 use core::arch::naked_asm;
 
-use crate::asm::Montgomery;
+use crate::sys::asm::Montgomery;
 
 /// Doubles a point in Jacobian form (with integers Montgomery form).
 ///

--- a/p256-cm4/src/asm/matrix.rs
+++ b/p256-cm4/src/asm/matrix.rs
@@ -313,9 +313,15 @@ pub(in crate::sys) unsafe extern "C" fn P256_divsteps2_31(
 ///
 /// # Return
 /// On return, the dereference of the input value of `r3` will contain the result of the operation.
+///
+/// # Safety
+/// The caller must guarantee that `fg` and `res` are valid for the duration of the function call,
+/// and that `res` is valid for writes.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn P256_matrix_mul_fg_9(
+pub(in crate::sys) unsafe extern "C" fn P256_matrix_mul_fg_9(
     a: u32,
     b: u32,
     fg: *const [FGInteger; 2],

--- a/p256-cm4/src/asm/matrix.rs
+++ b/p256-cm4/src/asm/matrix.rs
@@ -219,9 +219,20 @@ pub unsafe extern "C" fn P256_matrix_mul_mod_n(
 /// # Return
 /// On return, `r0` will contain `delta`, and the dereference of the input value of `r3` shall contain the result
 /// of the computation.
+///
+/// # Safety
+/// The caller must guarantee that `res`, is valid for the duration
+/// of the function call, and that `res` is valid for writes.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(no_mangle)]
 #[unsafe(naked)]
-pub unsafe extern "C" fn P256_divsteps2_31(delta: i32, f: u32, g: u32, res: *mut [u32; 4]) -> i32 {
+pub(in crate::sys) unsafe extern "C" fn P256_divsteps2_31(
+    delta: i32,
+    f: u32,
+    g: u32,
+    res: *mut [u32; 4],
+) -> i32 {
     naked_asm!(
         "
             push {r3, r4-r8, lr}

--- a/p256-cm4/src/asm/matrix.rs
+++ b/p256-cm4/src/asm/matrix.rs
@@ -24,12 +24,15 @@ struct MatrixElement(u32);
 /// # Return
 /// On return, the dereference of the input value of `r3` will contain the result of the computation.
 ///
-/// > **Note**: `r3` will be overriden during the execution of this function (it is callee-saved).
+/// # Safety
+/// The caller must guarantee that `out` and `xy` are valid for the duration of the function call,
+/// and that `out` is valid for writes.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 // TODO: replace `u32` with `MatrixElement`.
 #[unsafe(no_mangle)]
-// TODO: can we get rid of this `naked`? In theory, this function adheres to the ARM calling convention.
 #[unsafe(naked)]
-pub unsafe extern "C" fn P256_matrix_mul_mod_n(
+pub(in crate::sys) unsafe extern "C" fn P256_matrix_mul_mod_n(
     a: u32,
     b: u32,
     xy: *const [crate::XYInteger; 2],

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -27,9 +27,9 @@ mod verify;
 pub use verify::P256_verify_last_step;
 
 mod util;
+pub(super) use util::P256_check_range_n;
 pub use util::{
-    P256_check_range_n, P256_check_range_p, P256_negate_mod_n_if, P256_negate_mod_p_if,
-    add_sub_helper, mul288x288,
+    P256_check_range_p, P256_negate_mod_n_if, P256_negate_mod_p_if, add_sub_helper, mul288x288,
 };
 
 mod reduce;

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -31,10 +31,8 @@ pub(super) use util::{
 };
 pub use util::{add_sub_helper, mul288x288};
 
-mod reduce;
-pub(crate) use reduce::{
-    P256_reduce_mod_n_32bytes, P256_reduce_mod_n_64bytes, P256_reduce_mod_n_once,
-};
+pub mod reduce;
+pub(crate) use reduce::{P256_reduce_mod_n_64bytes, P256_reduce_mod_n_once};
 
 /// The order of the P256 curve.
 ///

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -75,13 +75,13 @@ pub(crate) static P256_PRIME: [u32; 8] =
 /// On return, `r0` will contain `1` if `xy` is on the `p256` curve. Otherwise, `r0` will contain `0`.
 ///
 /// # SAFETY
-/// The caller must guarantee that `x` and `y` are valid.
+/// The caller must guarantee that `x` and `y` are valid for the duration of the function call.
 ///
-/// This function adheres to the ARM calling convention.
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".p256-cortex-m4")]
 #[unsafe(naked)]
-pub unsafe extern "C" fn P256_point_is_on_curve(
+pub(in crate::sys) unsafe extern "C" fn P256_point_is_on_curve(
     x: *const Montgomery,
     y: *const Montgomery,
 ) -> bool {

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -27,10 +27,8 @@ mod verify;
 pub use verify::P256_verify_last_step;
 
 mod util;
-pub(super) use util::P256_check_range_n;
-pub use util::{
-    P256_check_range_p, P256_negate_mod_n_if, P256_negate_mod_p_if, add_sub_helper, mul288x288,
-};
+pub(super) use util::{P256_check_range_n, P256_check_range_p};
+pub use util::{P256_negate_mod_n_if, P256_negate_mod_p_if, add_sub_helper, mul288x288};
 
 mod reduce;
 pub(crate) use reduce::{

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -5,8 +5,8 @@ use core::arch::naked_asm;
 mod sqrmod;
 pub(crate) use sqrmod::P256_sqrmod;
 
-mod add_sub;
-pub(crate) use add_sub::{P256_add_mod_n, P256_addmod, P256_submod};
+pub mod add_sub;
+pub(crate) use add_sub::{P256_addmod, P256_submod};
 
 pub(crate) mod jacobian;
 

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -17,8 +17,8 @@ use montgomery::{P256_from_montgomery, P256_to_montgomery};
 mod sqrt;
 pub(crate) use sqrt::P256_modinv_sqrt;
 
-mod matrix;
-pub use matrix::{P256_divsteps2_31, P256_matrix_mul_fg_9, P256_matrix_mul_mod_n};
+pub mod matrix;
+pub use matrix::{P256_matrix_mul_fg_9, P256_matrix_mul_mod_n};
 
 pub mod mulmod;
 pub(crate) use mulmod::P256_mulmod;

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -27,8 +27,8 @@ mod verify;
 pub use verify::P256_verify_last_step;
 
 mod util;
-pub(super) use util::{P256_check_range_n, P256_check_range_p};
-pub use util::{P256_negate_mod_n_if, P256_negate_mod_p_if, add_sub_helper, mul288x288};
+pub(super) use util::{P256_check_range_n, P256_check_range_p, P256_negate_mod_n_if};
+pub use util::{P256_negate_mod_p_if, add_sub_helper, mul288x288};
 
 mod reduce;
 pub(crate) use reduce::{
@@ -378,7 +378,7 @@ pub unsafe extern "C" fn P256_decompress_point(
 /// > **Note**: `r0` will be overriden during the execution of this function (it is callee-saved).
 #[unsafe(no_mangle)]
 #[unsafe(naked)]
-pub unsafe extern "C" fn P256_negate_mod_m_if(
+extern "C" fn P256_negate_mod_m_if(
     output: *mut [u32; 8],
     a: *const [u32; 8],
     should_negate: u32,

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -27,8 +27,10 @@ mod verify;
 pub use verify::P256_verify_last_step;
 
 mod util;
-pub(super) use util::{P256_check_range_n, P256_check_range_p, P256_negate_mod_n_if};
-pub use util::{P256_negate_mod_p_if, add_sub_helper, mul288x288};
+pub(super) use util::{
+    P256_check_range_n, P256_check_range_p, P256_negate_mod_n_if, P256_negate_mod_p_if,
+};
+pub use util::{add_sub_helper, mul288x288};
 
 mod reduce;
 pub(crate) use reduce::{

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -261,13 +261,14 @@ pub unsafe extern "C" fn P256_sqrmod_many_and_mulmod() {
 ///
 ///
 /// # SAFETY
-/// The caller must guarantee that `x` and `y` are valid.
+/// The caller must guarantee that `x` and `y` are valid for the duration of the
+/// function call, and that `y` is valid for writes.
 ///
-/// This function adheres to the ARM calling convention.
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".p256-cortex-m4")]
 #[unsafe(naked)]
-pub unsafe extern "C" fn P256_decompress_point(
+pub(in crate::sys) unsafe extern "C" fn P256_decompress_point(
     y: *mut [u32; 8],
     x: *const [u32; 8],
     parity: u32,

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -20,8 +20,8 @@ pub(crate) use sqrt::P256_modinv_sqrt;
 mod matrix;
 pub use matrix::{P256_divsteps2_31, P256_matrix_mul_fg_9, P256_matrix_mul_mod_n};
 
-mod mulmod;
-pub(crate) use mulmod::{P256_mul_mod_n, P256_mulmod};
+pub mod mulmod;
+pub(crate) use mulmod::P256_mulmod;
 
 mod verify;
 pub use verify::P256_verify_last_step;

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -12,7 +12,8 @@ pub(crate) mod jacobian;
 pub use jacobian::P256_double_j;
 
 pub(crate) mod montgomery;
-pub use montgomery::{Montgomery, P256_from_montgomery, P256_to_montgomery};
+pub use montgomery::Montgomery;
+use montgomery::{P256_from_montgomery, P256_to_montgomery};
 
 mod sqrt;
 pub(crate) use sqrt::P256_modinv_sqrt;

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -23,8 +23,7 @@ pub use matrix::{P256_divsteps2_31, P256_matrix_mul_fg_9, P256_matrix_mul_mod_n}
 pub mod mulmod;
 pub(crate) use mulmod::P256_mulmod;
 
-mod verify;
-pub use verify::P256_verify_last_step;
+pub mod verify;
 
 mod util;
 pub(super) use util::{

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -9,7 +9,6 @@ mod add_sub;
 pub(crate) use add_sub::{P256_add_mod_n, P256_addmod, P256_submod};
 
 pub(crate) mod jacobian;
-pub use jacobian::P256_double_j;
 
 pub(crate) mod montgomery;
 pub use montgomery::Montgomery;

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -18,7 +18,7 @@ mod sqrt;
 pub(crate) use sqrt::P256_modinv_sqrt;
 
 pub mod matrix;
-pub use matrix::{P256_matrix_mul_fg_9, P256_matrix_mul_mod_n};
+pub use matrix::P256_matrix_mul_mod_n;
 
 pub mod mulmod;
 pub(crate) use mulmod::P256_mulmod;

--- a/p256-cm4/src/asm/mod.rs
+++ b/p256-cm4/src/asm/mod.rs
@@ -18,7 +18,6 @@ mod sqrt;
 pub(crate) use sqrt::P256_modinv_sqrt;
 
 pub mod matrix;
-pub use matrix::P256_matrix_mul_mod_n;
 
 pub mod mulmod;
 pub(crate) use mulmod::P256_mulmod;

--- a/p256-cm4/src/asm/mulmod.rs
+++ b/p256-cm4/src/asm/mulmod.rs
@@ -520,10 +520,14 @@ pub unsafe extern "C" fn P256_mulmod() {
 /// # Returns
 /// On return, the dereference of the input value of `r0` will contain the result of the computation.
 ///
-/// > **Note**: `r0` will be overriden during the execution of this function (it is callee-saved).
+/// # Safety
+/// The caller must guarantee that `res`, `a` and `b` are valid for the duration
+/// of the function call, and that `res` is valid for writes.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn P256_mul_mod_n(
+pub(in crate::sys) unsafe extern "C" fn P256_mul_mod_n(
     res: *mut [u32; 8],
     a: *const [u32; 8],
     b: *const [u32; 8],

--- a/p256-cm4/src/asm/reduce.rs
+++ b/p256-cm4/src/asm/reduce.rs
@@ -67,9 +67,18 @@ pub unsafe extern "C" fn P256_reduce_mod_n_once() {
 ///
 /// # Return
 /// On return, the dereference of the input value of `r0` shall contain the result of the computation.
+///
+/// # Safety
+/// The caller must guarantee that `res` and `a` are valid for the duration of the function call,
+/// and that `res` is valid for writes.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn P256_reduce_mod_n_32bytes(res: *mut [u32; 8], a: *const [u32; 8]) {
+pub(in crate::sys) unsafe extern "C" fn P256_reduce_mod_n_32bytes(
+    res: *mut [u32; 8],
+    a: *const [u32; 8],
+) {
     naked_asm!(
         "
             push {{r0, r4-r11, lr}}

--- a/p256-cm4/src/asm/reduce.rs
+++ b/p256-cm4/src/asm/reduce.rs
@@ -1,6 +1,6 @@
 use core::arch::naked_asm;
 
-use crate::asm::util::mul288x288;
+use crate::sys::asm::util::mul288x288;
 
 /// Given 288-bit value `a` and `n`, the P256 order:
 /// 1. if `a >= n`, calculate `a - n`

--- a/p256-cm4/src/asm/util.rs
+++ b/p256-cm4/src/asm/util.rs
@@ -186,9 +186,14 @@ pub(in crate::sys) unsafe extern "C" fn P256_check_range_n(a: *const [u32; 8]) -
 ///
 /// # Returns
 /// On return, `r0` will contain the result of the computation as a boolean.
+///
+/// # Safety
+/// The caller must guarantee that `a` is valid for the duration of the function call.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn P256_check_range_p(a: *const [u32; 8]) -> bool {
+pub(in crate::sys) unsafe extern "C" fn P256_check_range_p(a: *const [u32; 8]) -> bool {
     naked_asm!(
         "
             push {r4-r8, lr}

--- a/p256-cm4/src/asm/util.rs
+++ b/p256-cm4/src/asm/util.rs
@@ -266,10 +266,16 @@ pub unsafe extern "C" fn setzero() {
 /// On return, the dereference of the input value of `r0` shall contain the result of the computation.
 ///
 /// > **Note**: `r0` will be overriden during the execution of this function (it is callee-saved).
+///
+/// # Safety
+/// The caller must guarantee that `out` and `inn` are valid for the duration of the function
+/// call, and that `inn` is valid for writes.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".p256-cortex-m4")]
-pub unsafe extern "C" fn P256_negate_mod_n_if(
+pub(in crate::sys) unsafe extern "C" fn P256_negate_mod_n_if(
     out: *mut [u32; 8],
     inn: *const [u32; 8],
     should_negate: u32,

--- a/p256-cm4/src/asm/util.rs
+++ b/p256-cm4/src/asm/util.rs
@@ -308,11 +308,15 @@ pub(in crate::sys) unsafe extern "C" fn P256_negate_mod_n_if(
 /// # Return
 /// On return, the dereference of the input value of `r0` shall contain the result of the computation.
 ///
-/// > **Note**: `r0` will be overriden during the execution of this function (it is callee-saved).
+/// # Safety
+/// The caller must guarantee that `out` and `inn` are valid for the duration of the function
+/// call, and that `inn` is valid for writes.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".p256-cortex-m4")]
-pub unsafe extern "C" fn P256_negate_mod_p_if(
+pub(in crate::sys) unsafe extern "C" fn P256_negate_mod_p_if(
     out: *mut Montgomery,
     inn: *const Montgomery,
     should_negate: u32,

--- a/p256-cm4/src/asm/util.rs
+++ b/p256-cm4/src/asm/util.rs
@@ -135,10 +135,15 @@ pub unsafe extern "C" fn add_sub_helper() {
 ///
 /// # Return
 /// On return, `r0` will contain `1` if `a` was in the range, and `0` otherwise.
+///
+/// # Safety
+/// The caller must guarantee that `a` is valid for the duration of the function call.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".p256-cortex-m4")]
-pub unsafe extern "C" fn P256_check_range_n(a: *const [u32; 8]) -> bool {
+pub(in crate::sys) unsafe extern "C" fn P256_check_range_n(a: *const [u32; 8]) -> bool {
     naked_asm!(
         "
             push {{r4-r11, lr}}

--- a/p256-cm4/src/asm/util.rs
+++ b/p256-cm4/src/asm/util.rs
@@ -1,5 +1,7 @@
 use core::arch::naked_asm;
 
+use super::Montgomery;
+
 /// Given two 288 bit numbers `a` and `b`, calculate `a * b`.
 ///
 /// # Inputs
@@ -295,9 +297,9 @@ pub(in crate::sys) unsafe extern "C" fn P256_negate_mod_n_if(
 /// 2. Else, copy `a`.
 ///
 /// # Inputs
-/// `r0` shall contain a valid `*mut [u32; 8]`.
+/// `r0` shall contain a valid [`*mut Montgomery`](Montgomery).
 ///
-/// `r1` shall contain `a`, a valid `*const [u32; 8]`, where `1 <= a <= p - 1`.
+/// `r1` shall contain `a`, a valid [`*const Montgomery`](Montgomery), where `1 <= a <= p - 1`.
 ///
 /// `r2` shall contain `should_negate`, a `u32` that is either 1 or 0.
 ///
@@ -311,8 +313,8 @@ pub(in crate::sys) unsafe extern "C" fn P256_negate_mod_n_if(
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".p256-cortex-m4")]
 pub unsafe extern "C" fn P256_negate_mod_p_if(
-    out: *mut [u32; 8],
-    inn: *const [u32; 8],
+    out: *mut Montgomery,
+    inn: *const Montgomery,
     should_negate: u32,
 ) {
     naked_asm!(

--- a/p256-cm4/src/asm/verify.rs
+++ b/p256-cm4/src/asm/verify.rs
@@ -13,10 +13,16 @@ use crate::sys::asm::montgomery::Montgomery;
 ///
 /// # Return
 /// On return, `r0` will contain `1` if the check passes, and `0` otherwise.
+///
+/// # Safety
+/// The caller must guarantee that `r` and `x` are valid for the duration of the function
+/// call.
+///
+/// > **Note**: This function adheres to the ARM calling convention.
 #[unsafe(no_mangle)]
 #[unsafe(naked)]
 #[unsafe(link_section = ".p256-cortex-m4")]
-pub unsafe extern "C" fn P256_verify_last_step(
+pub(in crate::sys) unsafe extern "C" fn P256_verify_last_step(
     r: *const [u32; 8],
     x: *const [Montgomery; 3],
 ) -> bool {

--- a/p256-cm4/src/asm/verify.rs
+++ b/p256-cm4/src/asm/verify.rs
@@ -1,6 +1,6 @@
 use core::arch::naked_asm;
 
-use crate::asm::montgomery::Montgomery;
+use crate::sys::asm::montgomery::Montgomery;
 
 /// Perform the last step of verifying a P256 signature.
 ///

--- a/p256-cm4/src/lib.rs
+++ b/p256-cm4/src/lib.rs
@@ -4,13 +4,13 @@
 mod sys;
 
 use crate::sys::asm::{
-    P256_add_mod_n, P256_decompress_point, P256_divsteps2_31, P256_matrix_mul_fg_9, P256_mul_mod_n,
-    P256_negate_mod_p_if, P256_reduce_mod_n_32bytes, P256_verify_last_step,
+    P256_add_mod_n, P256_divsteps2_31, P256_matrix_mul_fg_9, P256_mul_mod_n, P256_negate_mod_p_if,
+    P256_reduce_mod_n_32bytes, P256_verify_last_step,
 };
 
 use sys::{
-    Montgomery, add_sub_j, add_sub_j_affine, double_j, double_j_inplace, jacobian_to_affine,
-    negate_mod_n_if, point_is_on_curve,
+    Montgomery, add_sub_j, add_sub_j_affine, decompress_point, double_j, double_j_inplace,
+    jacobian_to_affine, negate_mod_n_if, point_is_on_curve,
 };
 pub use sys::{check_range_n, check_range_p};
 
@@ -180,7 +180,7 @@ pub fn octet_string_to_point(x: &mut [u32; 8], y: &mut [u32; 8], input: &[u8]) -
 
             point_is_on_curve(&x, &y)
         } else if (input[0] >> 1) == 1 && input.len() == 33 {
-            unsafe { P256_decompress_point(y, x, u32::from(input[0] & 1)) }
+            decompress_point(y, x, u32::from(input[0] & 1) == 1)
         } else {
             false
         }

--- a/p256-cm4/src/lib.rs
+++ b/p256-cm4/src/lib.rs
@@ -5,9 +5,9 @@ mod sys;
 
 use sys::{
     Montgomery, add_mod_n_in_place, add_sub_j, add_sub_j_affine, decompress_point, divsteps2_31,
-    double_j, double_j_inplace, jacobian_to_affine, matrix_mul_fg_9, mul_mod_n, mul_mod_n_in_place,
-    negate_mod_n_if, negate_mod_p_if_in_place, point_is_on_curve, reduce_mod_n_32bytes_in_place,
-    verify_last_step,
+    double_j, double_j_inplace, jacobian_to_affine, matrix_mul_fg_9, matrix_mul_mod_n, mul_mod_n,
+    mul_mod_n_in_place, negate_mod_n_if, negate_mod_p_if_in_place, point_is_on_curve,
+    reduce_mod_n_32bytes_in_place, verify_last_step,
 };
 pub use sys::{check_range_n, check_range_p};
 
@@ -807,12 +807,8 @@ fn mod_n_inv(res: &mut [u32; 8], a: &[u32; 8]) {
 
         // Iterate the result vector
         // Due to montgomery multiplication inside this function, each step also adds a 2^-32 factor
-        unsafe {
-            sys::asm::P256_matrix_mul_mod_n(matrix[0], matrix[1], &i.xy, &mut i_plus_one.xy[0])
-        };
-        unsafe {
-            sys::asm::P256_matrix_mul_mod_n(matrix[2], matrix[3], &i.xy, &mut i_plus_one.xy[1])
-        };
+        matrix_mul_mod_n(matrix[0], matrix[1], &i.xy, &mut i_plus_one.xy[0]);
+        matrix_mul_mod_n(matrix[2], matrix[3], &i.xy, &mut i_plus_one.xy[1]);
     });
 
     // Calculates val^-1 = sgn(f) * v * 2^-744, where v is the "top-right corner" of the resulting T24*T23*...*T1 matrix.

--- a/p256-cm4/src/lib.rs
+++ b/p256-cm4/src/lib.rs
@@ -3,12 +3,12 @@
 
 mod sys;
 
-use crate::sys::asm::{P256_matrix_mul_fg_9, P256_reduce_mod_n_32bytes};
+use crate::sys::asm::P256_matrix_mul_fg_9;
 
 use sys::{
     Montgomery, add_mod_n_in_place, add_sub_j, add_sub_j_affine, decompress_point, divsteps2_31,
     double_j, double_j_inplace, jacobian_to_affine, mul_mod_n, mul_mod_n_in_place, negate_mod_n_if,
-    negate_mod_p_if_in_place, point_is_on_curve, verify_last_step,
+    negate_mod_p_if_in_place, point_is_on_curve, reduce_mod_n_32bytes_in_place, verify_last_step,
 };
 pub use sys::{check_range_n, check_range_p};
 
@@ -527,7 +527,7 @@ pub fn sign_step1(result: &mut SignPrecomp, k: &[u32; 8]) -> bool {
         mod_n_inv(&mut result.k_inv, k);
 
         output_x.write(&mut result.r);
-        unsafe { P256_reduce_mod_n_32bytes(&raw mut result.r, &raw const result.r) };
+        reduce_mod_n_32bytes_in_place(&mut result.r);
 
         let r_sum: u32 = (0..8).fold(0, |r_sum, i| r_sum | result.r[i]);
         if r_sum == 0 {

--- a/p256-cm4/src/lib.rs
+++ b/p256-cm4/src/lib.rs
@@ -4,13 +4,14 @@
 mod sys;
 
 use crate::sys::asm::{
-    P256_add_mod_n, P256_divsteps2_31, P256_matrix_mul_fg_9, P256_negate_mod_p_if,
-    P256_reduce_mod_n_32bytes, P256_verify_last_step,
+    P256_divsteps2_31, P256_matrix_mul_fg_9, P256_negate_mod_p_if, P256_reduce_mod_n_32bytes,
+    P256_verify_last_step,
 };
 
 use sys::{
-    Montgomery, add_sub_j, add_sub_j_affine, decompress_point, double_j, double_j_inplace,
-    jacobian_to_affine, mul_mod_n, mul_mod_n_in_place, negate_mod_n_if, point_is_on_curve,
+    Montgomery, add_mod_n_in_place, add_sub_j, add_sub_j_affine, decompress_point, double_j,
+    double_j_inplace, jacobian_to_affine, mul_mod_n, mul_mod_n_in_place, negate_mod_n_if,
+    point_is_on_curve,
 };
 pub use sys::{check_range_n, check_range_p};
 
@@ -596,7 +597,7 @@ pub fn sign_step2(
         }
         hash_to_z(u32x8_to_u8x32_mut(r), hash);
         mul_mod_n(s, &sign_precomp.r, private_key);
-        unsafe { P256_add_mod_n(s, r, s) };
+        add_mod_n_in_place(s, r);
         mul_mod_n_in_place(s, &sign_precomp.k_inv);
 
         r.copy_from_slice(&sign_precomp.r);

--- a/p256-cm4/src/lib.rs
+++ b/p256-cm4/src/lib.rs
@@ -777,7 +777,7 @@ fn mod_n_inv(res: &mut [u32; 8], a: &[u32; 8]) {
     state[0].fg[0].flip_sign = 0; // non-negative f
     state[0].fg[0]
         .signed_value
-        .copy_from_slice(&sys::asm::P256_ORDER); // f
+        .copy_from_slice(&sys::P256_ORDER); // f
     state[0].fg[1].flip_sign = 0; // non-negative g
     state[0].fg[1].signed_value[..8].copy_from_slice(a); // g
     state[0].fg[1].signed_value[8] = 0; // upper bits of g are 0

--- a/p256-cm4/src/lib.rs
+++ b/p256-cm4/src/lib.rs
@@ -6,10 +6,12 @@ mod sys;
 use crate::sys::asm::{
     P256_add_mod_n, P256_decompress_point, P256_divsteps2_31, P256_matrix_mul_fg_9, P256_mul_mod_n,
     P256_negate_mod_p_if, P256_point_is_on_curve, P256_reduce_mod_n_32bytes, P256_verify_last_step,
-    jacobian::P256_jacobian_to_affine,
 };
 
-use sys::{Montgomery, add_sub_j, add_sub_j_affine, double_j, double_j_inplace, negate_mod_n_if};
+use sys::{
+    Montgomery, add_sub_j, add_sub_j_affine, double_j, double_j_inplace, jacobian_to_affine,
+    negate_mod_n_if,
+};
 pub use sys::{check_range_n, check_range_p};
 
 // This table contains 1G, 3G, 5G, ... 15G in affine coordinates in montgomery form
@@ -252,7 +254,8 @@ fn scalarmult_variable_base(
         // attacker could easily test this case anyway.
         add_sub_j(&mut current_point, &selected_point, false);
     });
-    unsafe { P256_jacobian_to_affine(output_mont_x, output_mont_y, &current_point) };
+
+    jacobian_to_affine(output_mont_x, output_mont_y, &current_point);
 
     // If the scalar was initially even, we now negate the result to get the correct result, since -(scalar*G) = (-scalar*G).
     // This is done by negating y, since -(x,y) = (x,-y).
@@ -424,7 +427,7 @@ fn scalarmult_fixed_base(output_x: &mut Montgomery, output_y: &mut Montgomery, s
         }
     }
 
-    unsafe { P256_jacobian_to_affine(output_x, output_y, &current_point) };
+    jacobian_to_affine(output_x, output_y, &current_point);
 
     // Negate final result if the scalar was initially even.
     unsafe {

--- a/p256-cm4/src/lib.rs
+++ b/p256-cm4/src/lib.rs
@@ -3,14 +3,12 @@
 
 mod sys;
 
-use crate::sys::asm::{
-    P256_divsteps2_31, P256_matrix_mul_fg_9, P256_reduce_mod_n_32bytes, P256_verify_last_step,
-};
+use crate::sys::asm::{P256_divsteps2_31, P256_matrix_mul_fg_9, P256_reduce_mod_n_32bytes};
 
 use sys::{
     Montgomery, add_mod_n_in_place, add_sub_j, add_sub_j_affine, decompress_point, double_j,
     double_j_inplace, jacobian_to_affine, mul_mod_n, mul_mod_n_in_place, negate_mod_n_if,
-    negate_mod_p_if_in_place, point_is_on_curve,
+    negate_mod_p_if_in_place, point_is_on_curve, verify_last_step,
 };
 pub use sys::{check_range_n, check_range_p};
 
@@ -733,7 +731,7 @@ pub fn verify(
             }
         });
 
-    unsafe { P256_verify_last_step(&raw const *r, &raw const cp as _) }
+    verify_last_step(r, &cp)
 }
 
 #[repr(C)]

--- a/p256-cm4/src/lib.rs
+++ b/p256-cm4/src/lib.rs
@@ -4,14 +4,13 @@
 mod sys;
 
 use crate::sys::asm::{
-    P256_add_mod_n, P256_check_range_p, P256_decompress_point, P256_divsteps2_31, P256_double_j,
-    P256_from_montgomery, P256_matrix_mul_fg_9, P256_mul_mod_n, P256_negate_mod_n_if,
-    P256_negate_mod_p_if, P256_point_is_on_curve, P256_reduce_mod_n_32bytes, P256_to_montgomery,
-    P256_verify_last_step,
+    P256_add_mod_n, P256_decompress_point, P256_divsteps2_31, P256_double_j, P256_from_montgomery,
+    P256_matrix_mul_fg_9, P256_mul_mod_n, P256_negate_mod_n_if, P256_negate_mod_p_if,
+    P256_point_is_on_curve, P256_reduce_mod_n_32bytes, P256_to_montgomery, P256_verify_last_step,
     jacobian::{P256_add_sub_j, P256_jacobian_to_affine},
 };
 
-pub use sys::check_range_n;
+pub use sys::{check_range_n, check_range_p};
 
 const ONE_MONTGOMERY: [u32; 8] = [1, 0, 0, 0xffffffff, 0xffffffff, 0xffffffff, 0xfffffffe, 0];
 
@@ -101,17 +100,6 @@ fn abs_int(a: i8) -> u32 {
     result
 }
 
-/// Checks that the argument, as little-endian integer,
-/// is a reduced element of the base field.
-///
-/// In other words, that it is in the range `0..=p-1`,
-/// where `p = 2^256 - 2^224 + 2^192 + 2^96 - 1`.
-#[inline]
-#[must_use]
-pub fn check_range_p(a: &[u32; 8]) -> bool {
-    unsafe { P256_check_range_p(a) }
-}
-
 /// Converts endianness by reversing the input value.
 ///
 /// The output and input pointers may NOT refer to the same location
@@ -173,13 +161,13 @@ pub fn point_to_octet_string_hybrid(out: &mut [u8; 65], x: &[u32; 8], y: &[u32; 
 pub fn octet_string_to_point(x: &mut [u32; 8], y: &mut [u32; 8], input: &[u8]) -> bool {
     if let Ok(slice) = input[1..33].try_into() {
         convert_endianness(u32x8_to_u8x32_mut(x), slice);
-        if unsafe { !P256_check_range_p(x) } {
+        if !check_range_p(x) {
             return false;
         }
 
         if (input[0] == 4 || ((input[0] >> 1) == 3)) && input.len() == 65 {
             convert_endianness(u32x8_to_u8x32_mut(y), input[33..65].try_into().unwrap());
-            if unsafe { !P256_check_range_p(y) } {
+            if !check_range_p(y) {
                 return false;
             }
 
@@ -303,7 +291,7 @@ fn scalarmult_generic_no_scalar_check(
     in_x: &[u32; 8],
     in_y: &[u32; 8],
 ) -> bool {
-    if unsafe { !P256_check_range_p(in_x) || !P256_check_range_p(in_y) } {
+    if !check_range_p(in_x) || !check_range_p(in_y) {
         false
     } else {
         unsafe { P256_to_montgomery(&raw mut *output_mont_x as _, in_x) };
@@ -717,7 +705,7 @@ pub fn verify(
         return false;
     }
 
-    if unsafe { !P256_check_range_p(public_key_x) || !P256_check_range_p(public_key_y) } {
+    if !check_range_p(public_key_x) || !check_range_p(public_key_y) {
         return false;
     }
 

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -25,3 +25,10 @@ pub fn check_range_p(a: &[u32; 8]) -> bool {
     // SAFETY: `a` is valid for the duration of the call.
     unsafe { asm::P256_check_range_p(a) }
 }
+
+#[inline(always)]
+pub(crate) fn negate_mod_n_if(out: &mut [u32; 8], inn: &[u32; 8], should_negate: bool) {
+    // SAFETY: `out` and `inn` are valid for the duration of the call,
+    // and `out` is valid for writes.
+    unsafe { asm::P256_negate_mod_n_if(out, inn, should_negate as u32) };
+}

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -156,3 +156,13 @@ pub fn mul_mod_n_in_place(op: &mut [u32; 8], a: &[u32; 8]) {
     // The read and write pointers are allowed to overlap.
     unsafe { asm::mulmod::P256_mul_mod_n(op, a, op) }
 }
+
+/// Calculate `op = op + a mod n`, where `n` is the `p256`
+/// order.
+#[inline(always)]
+pub fn add_mod_n_in_place(op: &mut [u32; 8], a: &[u32; 8]) {
+    // SAFETY: `op` and `a` are valid for the duration of the
+    // function call, and `op` is valid for writes.
+    // The read and write pointers are allowed to overlap.
+    unsafe { asm::add_sub::P256_add_mod_n(op, a, op) };
+}

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -1,6 +1,8 @@
 #[path = "./asm/mod.rs"]
 #[cfg(target_arch = "arm")]
-pub(crate) mod asm;
+mod asm;
+
+pub(crate) use asm::P256_ORDER;
 
 pub use asm::montgomery::Montgomery;
 

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -177,3 +177,8 @@ pub fn negate_mod_p_if_in_place(a: &mut Montgomery, should_negate: bool) {
     // valid for writes. The read and write pointers are allowed to overlap.
     unsafe { asm::P256_negate_mod_p_if(a, a, should_negate as _) };
 }
+
+#[inline(always)]
+pub fn verify_last_step(r: &[u32; 8], x: &[Montgomery; 3]) -> bool {
+    unsafe { asm::verify::P256_verify_last_step(r, x) }
+}

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -4,6 +4,8 @@ pub(crate) mod asm;
 
 pub use asm::montgomery::Montgomery;
 
+use crate::sys::asm::P256_decompress_point;
+
 impl Montgomery {
     /// Set the contents of `self` to the montgomery representation
     /// of the little-endian integer `normal`.
@@ -130,4 +132,11 @@ pub fn jacobian_to_affine(x: &mut Montgomery, y: &mut Montgomery, jacobian: &[Mo
 pub fn point_is_on_curve(x: &Montgomery, y: &Montgomery) -> bool {
     // SAFETY: `x` and `y` are valid for the duration of the function call.
     unsafe { asm::P256_point_is_on_curve(x, y) }
+}
+
+#[inline(always)]
+pub fn decompress_point(y: &mut [u32; 8], x: &[u32; 8], odd: bool) -> bool {
+    // SAFTEY: `x` and `y` are valid for the duration of the function
+    // call, and `y` ìs valid for writes.
+    unsafe { P256_decompress_point(y, x, odd as _) }
 }

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -4,7 +4,7 @@ pub(crate) mod asm;
 
 pub use asm::montgomery::Montgomery;
 
-use crate::sys::asm::P256_decompress_point;
+use crate::sys::asm::{P256_decompress_point, matrix::P256_divsteps2_31};
 
 impl Montgomery {
     /// Set the contents of `self` to the montgomery representation
@@ -180,5 +180,14 @@ pub fn negate_mod_p_if_in_place(a: &mut Montgomery, should_negate: bool) {
 
 #[inline(always)]
 pub fn verify_last_step(r: &[u32; 8], x: &[Montgomery; 3]) -> bool {
+    // SAFETY: `r` and `x` are valid for the duration of the function
+    // call.
     unsafe { asm::verify::P256_verify_last_step(r, x) }
+}
+
+#[inline(always)]
+pub fn divsteps2_31(delta: i32, f: u32, g: u32, res: &mut [u32; 4]) -> i32 {
+    // SAFETY: `res` is valid for the duration of the function call,
+    // and is valid for writes.
+    unsafe { P256_divsteps2_31(delta, f, g, res) }
 }

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -191,3 +191,12 @@ pub fn divsteps2_31(delta: i32, f: u32, g: u32, res: &mut [u32; 4]) -> i32 {
     // and is valid for writes.
     unsafe { P256_divsteps2_31(delta, f, g, res) }
 }
+
+#[inline(always)]
+pub fn reduce_mod_n_32bytes_in_place(op: &mut [u32; 8]) {
+    // sAFETY: `op` is valid for the duration of the function
+    // call, and is valid for writes.
+    // The read and write pointer in this function are allowed
+    // to overlap.
+    unsafe { asm::reduce::P256_reduce_mod_n_32bytes(op, op) };
+}

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -125,3 +125,9 @@ pub fn jacobian_to_affine(x: &mut Montgomery, y: &mut Montgomery, jacobian: &[Mo
     // `x` and `y` are valid for writes.
     unsafe { asm::jacobian::P256_jacobian_to_affine(x, y, jacobian) };
 }
+
+#[inline(always)]
+pub fn point_is_on_curve(x: &Montgomery, y: &Montgomery) -> bool {
+    // SAFETY: `x` and `y` are valid for the duration of the function call.
+    unsafe { asm::P256_point_is_on_curve(x, y) }
+}

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -1,0 +1,3 @@
+#[path = "./asm/mod.rs"]
+#[cfg(target_arch = "arm")]
+pub(crate) mod asm;

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -166,3 +166,14 @@ pub fn add_mod_n_in_place(op: &mut [u32; 8], a: &[u32; 8]) {
     // The read and write pointers are allowed to overlap.
     unsafe { asm::add_sub::P256_add_mod_n(op, a, op) };
 }
+
+/// If `should_negate`, calculate `a = p - a`. Otherwise, this function
+/// is a no-op (but probably does constant-time things).
+///
+/// `1 <= 1 <= p - 1` must hold.
+#[inline(always)]
+pub fn negate_mod_p_if_in_place(a: &mut Montgomery, should_negate: bool) {
+    // SAFETY: `a` is valid for the duration of the function call, and is
+    // valid for writes. The read and write pointers are allowed to overlap.
+    unsafe { asm::P256_negate_mod_p_if(a, a, should_negate as _) };
+}

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -89,3 +89,17 @@ pub(crate) fn negate_mod_n_if(out: &mut [u32; 8], inn: &[u32; 8], should_negate:
     // and `out` is valid for writes.
     unsafe { asm::P256_negate_mod_n_if(out, inn, should_negate as u32) };
 }
+
+#[inline(always)]
+pub(crate) fn add_sub_j_affine(a: &mut [Montgomery; 3], b: &[Montgomery; 2], is_sub: bool) {
+    // SAFETY: `a` and `b` are valid for the duration of the call, `a` is valid
+    // for writes, and `b` has the correct length (2) for the value of `b_is_affine`.
+    unsafe { asm::jacobian::P256_add_sub_j(a, b.as_ptr(), is_sub, true) }
+}
+
+#[inline(always)]
+pub(crate) fn add_sub_j(a: &mut [Montgomery; 3], b: &[Montgomery; 3], is_sub: bool) {
+    // SAFETY: `a` and `b` are valid for the duration of the call, `a` is valid
+    // for writes, and `b` has the correct length (3) for the value of `b_is_affine`.
+    unsafe { asm::jacobian::P256_add_sub_j(a, b.as_ptr(), is_sub, false) }
+}

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -13,3 +13,15 @@ pub fn check_range_n(a: &[u32; 8]) -> bool {
     // SAFETY: `a` is valid for the duration of the call.
     unsafe { asm::P256_check_range_n(a) }
 }
+
+/// Checks that the argument, as little-endian integer,
+/// is a reduced element of the base field.
+///
+/// In other words, that it is in the range `0..=p-1`,
+/// where `p = 2^256 - 2^224 + 2^192 + 2^96 - 1`.
+#[inline(always)]
+#[must_use]
+pub fn check_range_p(a: &[u32; 8]) -> bool {
+    // SAFETY: `a` is valid for the duration of the call.
+    unsafe { asm::P256_check_range_p(a) }
+}

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -5,7 +5,7 @@ pub(crate) mod asm;
 pub use asm::montgomery::Montgomery;
 
 use crate::{
-    FGInteger,
+    FGInteger, XYInteger,
     sys::asm::{P256_decompress_point, matrix::P256_divsteps2_31},
 };
 
@@ -209,4 +209,14 @@ pub fn matrix_mul_fg_9(a: u32, b: u32, fg: &[FGInteger; 2], res: &mut FGInteger)
     // SAFETY: `fg` and `res` are valid for the duration of the function
     // call, and `res` is valid for writes.
     unsafe { asm::matrix::P256_matrix_mul_fg_9(a, b, fg, res) }
+}
+
+/// For MatrixElements `a` and `b`, and [`XYInteger`] `x` and `y`,
+/// compute `a * x + b * y mod N` (where N is the order of the p256 curve)
+/// and store the result in `out`.
+#[inline(always)]
+pub fn matrix_mul_mod_n(a: u32, b: u32, xy: &[XYInteger; 2], out: &mut XYInteger) {
+    // SAFETY: `out` and `xy` are valid for the duration of the function call, and
+    // `out` is valid for writes.
+    unsafe { asm::matrix::P256_matrix_mul_mod_n(a, b, xy, out) }
 }

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -118,3 +118,10 @@ pub(crate) fn double_j_inplace(jacobian: &mut [Montgomery; 3]) {
     // passed to `P256_double_j` may overlap.
     unsafe { asm::jacobian::P256_double_j(jacobian, jacobian) };
 }
+
+#[inline(always)]
+pub fn jacobian_to_affine(x: &mut Montgomery, y: &mut Montgomery, jacobian: &[Montgomery; 3]) {
+    // SAFETY: `x`, `y` and `jacobian` are valid for the duration of the function call,
+    // `x` and `y` are valid for writes.
+    unsafe { asm::jacobian::P256_jacobian_to_affine(x, y, jacobian) };
+}

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -4,7 +4,10 @@ pub(crate) mod asm;
 
 pub use asm::montgomery::Montgomery;
 
-use crate::sys::asm::{P256_decompress_point, matrix::P256_divsteps2_31};
+use crate::{
+    FGInteger,
+    sys::asm::{P256_decompress_point, matrix::P256_divsteps2_31},
+};
 
 impl Montgomery {
     /// Set the contents of `self` to the montgomery representation
@@ -199,4 +202,11 @@ pub fn reduce_mod_n_32bytes_in_place(op: &mut [u32; 8]) {
     // The read and write pointer in this function are allowed
     // to overlap.
     unsafe { asm::reduce::P256_reduce_mod_n_32bytes(op, op) };
+}
+
+#[inline(always)]
+pub fn matrix_mul_fg_9(a: u32, b: u32, fg: &[FGInteger; 2], res: &mut FGInteger) {
+    // SAFETY: `fg` and `res` are valid for the duration of the function
+    // call, and `res` is valid for writes.
+    unsafe { asm::matrix::P256_matrix_mul_fg_9(a, b, fg, res) }
 }

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -103,3 +103,18 @@ pub(crate) fn add_sub_j(a: &mut [Montgomery; 3], b: &[Montgomery; 3], is_sub: bo
     // for writes, and `b` has the correct length (3) for the value of `b_is_affine`.
     unsafe { asm::jacobian::P256_add_sub_j(a, b.as_ptr(), is_sub, false) }
 }
+
+#[inline(always)]
+pub(crate) fn double_j(jacobian_out: &mut [Montgomery; 3], jacobian_in: &[Montgomery; 3]) {
+    // SAFETY: `jacobian_out` and `jacobian_in` are valid for the duration of the
+    // function call, and `jacobian_out` is valid for writes.
+    unsafe { asm::jacobian::P256_double_j(jacobian_out, jacobian_in) };
+}
+
+#[inline(always)]
+pub(crate) fn double_j_inplace(jacobian: &mut [Montgomery; 3]) {
+    // SAFETY: `jacobian` is valid for the duration of the functino call,
+    // `jacobian` is valid for writes. Additionally, the read and write pointers
+    // passed to `P256_double_j` may overlap.
+    unsafe { asm::jacobian::P256_double_j(jacobian, jacobian) };
+}

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -1,3 +1,15 @@
 #[path = "./asm/mod.rs"]
 #[cfg(target_arch = "arm")]
 pub(crate) mod asm;
+
+/// Checks that the argument, as little-endian integer,
+/// is a reduced non-zero element of the scalar field.
+///
+/// In other words, that it is in the range `1..=n-1`,
+/// where `n = 2^256 - 2^224 + 2^192 - 0x4319055258e8617b0c46353d039cdaaf`.
+#[inline(always)]
+#[must_use]
+pub fn check_range_n(a: &[u32; 8]) -> bool {
+    // SAFETY: `a` is valid for the duration of the call.
+    unsafe { asm::P256_check_range_n(a) }
+}

--- a/p256-cm4/src/sys.rs
+++ b/p256-cm4/src/sys.rs
@@ -140,3 +140,19 @@ pub fn decompress_point(y: &mut [u32; 8], x: &[u32; 8], odd: bool) -> bool {
     // call, and `y` ìs valid for writes.
     unsafe { P256_decompress_point(y, x, odd as _) }
 }
+
+#[inline(always)]
+pub fn mul_mod_n(res: &mut [u32; 8], a: &[u32; 8], b: &[u32; 8]) {
+    // SAFETY: `res`, `a` and `b` are valid for the duration of the
+    // function call, and `res` is valid for writes.
+    unsafe { asm::mulmod::P256_mul_mod_n(res, a, b) }
+}
+
+/// Perform `mul_mod_n(op, a, op)`.
+#[inline(always)]
+pub fn mul_mod_n_in_place(op: &mut [u32; 8], a: &[u32; 8]) {
+    // SAFETY: `op` and `a` are valid for the duration of the
+    // function call, and `op` is valid for writes.
+    // The read and write pointers are allowed to overlap.
+    unsafe { asm::mulmod::P256_mul_mod_n(op, a, op) }
+}


### PR DESCRIPTION
This PR adds a `sys` module in between `lib` and `asm`.

The intention is to use it as a layer between the (`unsafe`) asm definitions and to provide safe abstractions over them that can be used in `lib`.

This will make all code in `lib` more idiomatic, and a little easier to grasp. The eventual goal is to build better abstractions on top of the current functions (closer to `p256-cortex-m4` and `p256`) and to implement some rust-crypto traits. 

It's a somewhat sweeping PR, once again, but hopefully in a form that is understandable enough :) The commits themselves are all testable.

Cycle-wise, these are the differences (tested on an STM32H723ZG):

| What   | Before  | After   | Delta (%)    |
| :----- | :------ | :------ | :----------- |
| Verify | 1381103 | 1388683 | +7580 (+0.5) |
| Sign   | 522746  | 519726  | -3019 (-0.6) |

The difference seem, to me, neglegible and/or layout/optimizer noise.

When swapping out for a RAM-runner (i.e. the entire binary is in the RAM memory of the STM32H7), the results look as follows:

| What   | Before | After  | Delta (%)    |
| :----- | :----- | :----- | :----------- |
| Verify | 856248 | 859422 | +3174 (+0.3) |
| Sign   | 322074 | 318211 | -3863 (-1.1) |

So I think it's just a few extra memory accesses that make a difference, but still neglegible (and signing becomes faster in both cases!)
