### PR TITLE
Call semihosting exit on panic to exit out of QEMU

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,5 @@ debug = 2
 debug-assertions = false
 incremental = false
 lto = false
-opt-level = 3 
+opt-level = 3
 overflow-checks = false

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -14,9 +14,9 @@ harness = false
 
 [dependencies]
 cortex-m = { version = "0.7.7", features = [ "critical-section-single-core" ] }
+cortex-m-semihosting = "0.5.0"
 defmt = "1.0"
 defmt-semihosting = "0.3"
 defmt-test = "0.4"
 hex-literal = "1.0.0"
 p256-cm4.path = "../p256-cm4"
-panic-probe = { version = "1.0", features = ["print-defmt" ] }

--- a/testsuite/src/basic.rs
+++ b/testsuite/src/basic.rs
@@ -1,17 +1,26 @@
 #![no_std]
 #![no_main]
+#![cfg(test)]
 
 use cortex_m::peripheral::DWT;
 use defmt::unwrap;
 use defmt_semihosting as _; // global logger
 use hex_literal::hex;
-use panic_probe as _;
 
 const FREQ: u32 = 48_000_000;
 const CYC_PER_MICRO: u32 = FREQ / 1000 / 1000;
 
 // WARNING will wrap-around eventually, use this for relative timing only
 defmt::timestamp!("{=u32:us}", DWT::cycle_count() / CYC_PER_MICRO);
+
+#[panic_handler]
+fn panic_handler(info: &core::panic::PanicInfo) -> ! {
+    use cortex_m_semihosting::debug;
+
+    defmt::error!("{}", defmt::Display2Format(info));
+    debug::exit(debug::EXIT_FAILURE);
+    loop {}
+}
 
 // Message hash
 const HASH: [u32; 8] = [


### PR DESCRIPTION
Instead of hanging forever (which is what QEMU seems to do on a panic from panic_probe), add an extra `semihosting::syscall!(REPORT_EXCEPTION)` instruction in the panic handler that will actually exit QEMU.