### PR TITLE
Update README and add `rtt` feature to test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/newAM/p256-cm4/workflows/CI/badge.svg)](https://github.com/newAM/p256-cm4/actions)
 [![crates.io](https://img.shields.io/crates/v/p256-cm4.svg)](https://crates.io/crates/p256-cm4)
-[![docs](https://docs.rs/p256-cm4/badge.svg)](https://docs.rs/p256-cm4) 
+[![docs](https://docs.rs/p256-cm4/badge.svg)](https://docs.rs/p256-cm4)
 
 A (mostly) rust re-implementation of [Emill/P256-Cortex-M4].
 
@@ -28,20 +28,10 @@ As measured on a STM32WLE5.
 
 ### Testing
 
-Install [probe-rs-tools].
-
-Adjust `.cargo/config.toml`, `memory.x`, `testsuite/Cargo.toml`, and the clock setup for your target.
+Install [qemu-system-arm] (tested to work with `qemu-system-arm 8.2.2`).
 
 ```bash
-DEFMT_LOG=trace cargo test -p testsuite
-```
-
-### ASM Generation
-
-Send the GCC ASM from [Emill/P256-Cortex-M4] through the pre-processor.
-
-```bash
-arm-none-eabi-gcc -O0 -ffunction-sections -fdata-sections -g -fno-omit-frame-pointer -mthumb -march=armv7e-m -Wall -Wextra -std=c11 -march=armv7e-m -c P256-Cortex-M4/p256-cortex-m4-asm-gcc.S -E > asm.s
+DEFMT_LOG=trace cargo test -p testsuite --target thumbv7em-none-eabi
 ```
 
 [Emill/P256-Cortex-M4]: https://github.com/Emill/P256-Cortex-M4
@@ -49,4 +39,4 @@ arm-none-eabi-gcc -O0 -ffunction-sections -fdata-sections -g -fno-omit-frame-poi
 [ycrypto/p256-cortex-m4]: https://github.com/ycrypto/p256-cortex-m4
 [ycrypto/p256-cortex-m4-sys]: https://github.com/ycrypto/p256-cortex-m4-sys
 [RustCrypto]: https://github.com/RustCrypto/elliptic-curves
-[probe-rs-tools]: https://probe.rs/docs/getting-started/installation/
+[qemu-system-arm]: https://www.qemu.org/docs/master/system/target-arm.html

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -16,7 +16,12 @@ harness = false
 cortex-m = { version = "0.7.7", features = [ "critical-section-single-core" ] }
 cortex-m-semihosting = "0.5.0"
 defmt = "1.0"
+defmt-rtt = { version = "1.1.0", optional = true }
 defmt-semihosting = "0.3"
 defmt-test = "0.4"
 hex-literal = "1.0.0"
 p256-cm4.path = "../p256-cm4"
+
+[features]
+# Use RTT instead of semihosting for logs
+rtt = [ "dep:defmt-rtt" ]

--- a/testsuite/src/basic.rs
+++ b/testsuite/src/basic.rs
@@ -4,8 +4,13 @@
 
 use cortex_m::peripheral::DWT;
 use defmt::unwrap;
-use defmt_semihosting as _; // global logger
 use hex_literal::hex;
+
+#[cfg(not(feature = "rtt"))]
+use defmt_semihosting as _;
+
+#[cfg(feature = "rtt")]
+use defmt_rtt as _;
 
 const FREQ: u32 = 48_000_000;
 const CYC_PER_MICRO: u32 = FREQ / 1000 / 1000;


### PR DESCRIPTION
Update README to reflect the new state of affairs, and add instructions for how to run on real hardware.

Also add an `rtt` feature to the test suite so that `probe-rs` logs come out looking pretty.