### PR TITLE
Add original copyright headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,7 @@
 MIT License
 
+Copyright (c) 2017-2021 Emil Lenngren # Original Assembly Implementation from which this work is derived
+Copyright (c) 2021 Shortcut Labs AB # Original Assembly Implementation from which this work is derived
 Copyright (c) 2022-present Alex Martens
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Since this is a derived work, we should include the original copyright owners in the LICENSE text.