### PR TITLE
Add note about making `qemu-decode` not slow down `rust-analyzer` when building for `no_std` target

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ As measured on a STM32WLE5.
 
 ## Maintainers Notes
 
+### Using VSCode with `rust-analyzer` in a multi-target workspace
+
+Since `qemu-decode` requires `std`, compiling it for `thumbv7em-none-eabi` spits out a lot of errors which massively slows down `rust-analyzer` if you
+try to change the compilation target for `p256-cm4` and `testsuite`.
+
+By default, VSCode configures `rust-analyzer` to run `cargo` on the entire workspace. However, to prevent `rust-analyzer` from trying to compile packages
+for targets they are not intended to compile for, you can open an individual project (e.g. `code p256-cm4/` or `code testsuite/`) and set
+the following settings in your `.vscode/config.json`:
+
+```json
+{
+    "rust-analyzer.check.workspace": false,
+    "rust-analyzer.cargo.target": "thumbv7em-none-eabi"
+}
+```
+
 ### Testing
 
 Install [probe-rs-tools].


### PR DESCRIPTION
When using `rust-analyzer` (through VSCode, at least), the build target can only be set on the workspace level. Additionally, all non-excluded targets are always built with the configured target (even if you've opened the workspace in a subdirectory, e.g. `code p256-cm4/p256-cm4`).

This means that, whichever approach one uses, at least one crate will not be compiled for its target (a target with `std` for `qemu-decoder`, `no_std` + `arm` for `p256-cm4` and `testsuite`).

As a result, the development experience is kind of crap, unfortunately: I either don't get to compile `p256-cm4` and `testsuite`, or I have to wait for `rust-analyzer` to finish spitting out the 1000+ errors that are generated when attempting to compile `qemu-decode`  for a `no-std` target.

As far as I am aware support for multi-target workspaces is very limited and unwieldy at this moment in time, so I would be grateful if we could make a change to make this work a little better by default.

My only real suggestion so far is that we exclude `qemu-decoder` from the workspace, set the runner to just `qemu-decoder`, and add a `cargo install --path qemu-decoder/` instruction to the readme.

I'm fine if you decide to close this as a non-planned feature, but wanted to put up this PR to see if you'd be amenable to it.